### PR TITLE
Remove Stray WEB_URL from CLIPP Email

### DIFF
--- a/src/emails/clipp_course_register_confirm.hbs
+++ b/src/emails/clipp_course_register_confirm.hbs
@@ -17,7 +17,7 @@ subject: Confirmation - {course_info:title}
 <table class="header" align="center"  width="100%" cellspacing="0" cellpadding="0" bgcolor="#FDFDFE"  border="0">
     <tr>
         <td class="wrapper border-bottom" valign="middle">
-            <a href="\{{WEB_URL}}"><img class="logo" border="0" src="https://media.nkba.org/img/nkba-logo@2x.png" alt="NKBA" height="30" width="141"></a>
+            <a href="https://nkba.org"><img class="logo" border="0" src="https://media.nkba.org/img/nkba-logo@2x.png" alt="NKBA" height="30" width="141"></a>
         </td>
     </tr>
 </table>
@@ -28,7 +28,7 @@ subject: Confirmation - {course_info:title}
 
                 <tr>
                     <td class="content-block text-4 pt1 " valign="top">
-                        <a href="\{{WEB_URL}}"><img border="0" src="https://media.nkba.org/wp-content/uploads/2018/09/27134716/clipp-institute-e1538070565197.jpg" alt="NKBA" height="100" width="100"></a>
+                        <a href="https://www.livinginplace.institute"><img border="0" src="https://media.nkba.org/wp-content/uploads/2018/09/27134716/clipp-institute-e1538070565197.jpg" alt="NKBA" height="100" width="100"></a>
                     </td>
                 </tr>   
                 <tr>


### PR DESCRIPTION
WEB_URL is undefined as this email is fired through Wordpress, not through our server. Replacing with hardcoded URL.